### PR TITLE
point to latest DOI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![DOI](https://zenodo.org/badge/356253588.svg)](https://zenodo.org/badge/latestdoi/356253588)
+[![DOI](https://zenodo.org/badge/383864835.svg)](https://zenodo.org/badge/latestdoi/383864835)
 
 # PC-MOSS Historical Archive
 


### PR DESCRIPTION
- it was incorrectly pointing to old `ploewe/MOSS` repository